### PR TITLE
Windows compatibility for suppressing StdErr

### DIFF
--- a/src/Executor/Result.php
+++ b/src/Executor/Result.php
@@ -11,7 +11,11 @@ class Result {
     $output = [];
     $return_val = 0;
     // Suppress StdErr output.
-    $command .= ' 2> /dev/null';
+    $dev_null = ' 2> /dev/null';
+    if (stripos(PHP_OS, 'win') !== FALSE) {
+      $dev_null = ' 2> nul';
+    }
+    $command .= $dev_null;
     exec($command, $output, $return_val);
 
     // Datetime weirdness. Apparently this is caused by theming issues on the


### PR DESCRIPTION
Just came across this issue when running the command on a cygwin / msys setup on windows.
Without the change the command will always fail.
