### PR TITLE
Entity reference fields non autocomplete

### DIFF
--- a/profiles/govcms_saas.yml
+++ b/profiles/govcms_saas.yml
@@ -84,3 +84,7 @@ checks :
     max_size : 5
     warning_size : 2
   \SiteAudit\Check\Phantomas\InPage404s : {}
+
+  # Field specific checks.
+  \SiteAudit\Check\D7\EntityReferenceAutocomplete:
+    threshold: 100

--- a/src/AuditResponse/AuditResponse.php
+++ b/src/AuditResponse/AuditResponse.php
@@ -79,7 +79,8 @@ class AuditResponse {
   }
 
   public function getRemediation() {
-    return $this->check->getInfo()->remediation;
+    $tokens = $this->check->getTokens();
+    return strtr($this->check->getInfo()->remediation, $tokens);
   }
 
   public function setStatus($status) {

--- a/src/Check/D7/EntityReferenceAutocomplete.php
+++ b/src/Check/D7/EntityReferenceAutocomplete.php
@@ -133,7 +133,7 @@ class EntityReferenceAutocomplete extends Check {
     list($count) = explode("\t", reset($output));
 
     if ($count > $this->getOption('threshold', 100)) {
-      $this->errors[$field_info['id']] = "{$field_instance_info['label']} ($count)";
+      $this->errors[$field_info['id']] = "{$field_instance_info['label']} ({$field_info['id']})";
       return FALSE;
     }
 
@@ -168,7 +168,7 @@ class EntityReferenceAutocomplete extends Check {
     list($count) = explode("\t", reset($output));
 
     if ($count > $this->getOption('threshold', 100)) {
-      $this->errors[$field_info['id']] = "{$field_instance_info['label']} ($count)";
+      $this->errors[$field_info['id']] = "{$field_instance_info['label']} ({$field_info['id']})";
       return FALSE;
     }
 

--- a/src/Check/D7/EntityReferenceAutocomplete.php
+++ b/src/Check/D7/EntityReferenceAutocomplete.php
@@ -1,0 +1,177 @@
+<?php
+/**
+ * @file
+ * Contains SiteAudit\Check\D7\EntityReferenceAutocomplete
+ */
+
+namespace SiteAudit\Check\D7;
+
+use SiteAudit\Check\Check;
+use SiteAudit\AuditResponse\AuditResponse;
+use SiteAudit\Annotation\CheckInfo;
+
+/**
+ * @CheckInfo(
+ *  title = "Entity reference autocomplete",
+ *  description = "Ensure that entity reference fields are configured correctly.",
+ *  remediation = "Change the following field definitions to autocomplete - <br/>:error_replace.",
+ *  success = "Found <code>:num_fields</code> entity reference field:num_plural configured correctly.",
+ *  failure = "Found configuration errors in <code>:error_count</code> entity reference field:error_plural.",
+ *  exception = "Could not find any entity reference fields.",
+ *  not_available = "No entity reference fields.",
+ * )
+ */
+class EntityReferenceAutocomplete extends Check {
+
+  protected $errors = [];
+
+  /**
+   * Identify if entity reference fields are displaying select lists.
+   *
+   * Sites can see crippling performance if an entity reference field is being
+   * used to display entities from a large node pool. This process will never
+   * fail with max_execution_time and as a result can cause PHP-FPM to backup
+   * and queue requests while it deals with an errant entity reference field.
+   *
+   * @return int AuditResponse::AUDIT_SUCCESS or similar.
+   */
+  protected function check() {
+    $valid = 0;
+
+    try {
+      $output = $this->context->drush->sqlQuery('SELECT fc.field_name, fc.data, fci.data FROM {field_config} fc JOIN {field_config_instance} fci ON fc.id = fci.field_id WHERE fc.type = \'entityreference\'');
+    } catch (\Exception $e) {
+      return AuditResponse::AUDIT_FAILURE;
+    }
+
+    foreach ($output as $line) {
+      list($field_name, $field_info, $field_instance_info) = explode("\t", $line);
+      $field_info = unserialize($field_info);
+      $field_instance_info = unserialize($field_instance_info);
+
+      if (strpos($field_instance_info['widget']['type'], 'autocomplete') > -1) {
+        // Correct configuration is to use an autocomplete as this will limit
+        // the number of referenced entities from being rendered.
+        $valid++;
+        continue;
+      }
+
+      $check = "check_{$field_info['settings']['target_type']}";
+
+      if (method_exists($this, $check)) {
+        if (call_user_func([$this, $check], $field_info, $field_instance_info)) {
+          $valid++;
+        }
+      }
+    }
+
+
+    $this->setToken('num_fields', $valid);
+    $this->setToken('num_plural', $valid > 1 ? 's' : '');
+    $this->setToken('error_replace', implode(', ',  $this->errors));
+    $this->setToken('error_count', count($this->errors));
+    $this->setToken('error_plural', count($this->errors) > 1 ? 's' : '');
+
+    if (!empty($this->errors)) {
+      return AuditResponse::AUDIT_FAILURE;
+    }
+
+    return AuditResponse::AUDIT_SUCCESS;
+  }
+
+  /**
+   * Attempt to extract field arguments from the settings arrays.
+   *
+   * @param array $field_info
+   *   A field info array.
+   *
+   * @return array
+   */
+  private function getFieldArgs(array $field_info) {
+    $args = [];
+
+    $handler_settings = isset($field_info['settings']['handler_settings']) ? $field_info['settings']['handler_settings'] : NULL;
+
+    if (empty($handler_settings)) {
+      return $args;
+    }
+
+    // Attempt to find the node types in the $field_info.
+    if (isset($handler_settings['target_bundles'])) {
+      $args = array_keys($handler_settings['target_bundles']);
+    }
+    elseif (isset($handler_settings['view']['args'])) {
+      $args = $handler_settings['view']['args'];
+    }
+
+    return $args;
+  }
+
+  /**
+   * Check method for an entity reference field referencing terms.
+   *
+   * @param array $field_info
+   *   A field info array.
+   * @param $field_instance_info
+   *   A particular field instance info array.
+   *
+   * @return bool|null
+   */
+  private function check_taxonomy_term($field_info, $field_instance_info) {
+    $bundles = $this->getFieldArgs($field_info);
+
+    if (empty($bundles)) {
+      return $this->getOption('implicit', TRUE);
+    }
+
+    try {
+      $output = $this->context->drush->sqlQuery('SELECT count(ttd.tid) as count FROM {taxonomy_term_data} ttd');
+    } catch(\Exception $e) {
+      return $this->getOption('implicit', TRUE);
+    }
+
+    list($count) = explode("\t", reset($output));
+
+    if ($count > $this->getOption('threshold', 100)) {
+      $this->errors[$field_info['id']] = "{$field_instance_info['label']} ($count)";
+      return FALSE;
+    }
+
+    return TRUE;
+  }
+
+  /**
+   * Check method for an entity reference field referencing nodes.
+   *
+   * @param array $field_info
+   *   A field info array.
+   * @param $field_instance_info
+   *   A particular field instance info array.
+   *
+   * @return bool|null
+   */
+  private function check_node(array $field_info, array $field_instance_info) {
+    $node_types = $this->getFieldArgs($field_info);
+
+    if (empty($node_types)) {
+      return $this->getOption('implicit', TRUE);
+    }
+
+    $node_types = "'" . implode("','", $node_types) . "'";
+
+    try {
+      $output = $this->context->drush->sqlQuery('SELECT count(node.nid) as count FROM {node} node WHERE node.type in (' . $node_types . ')');
+    } catch (\Exception $e) {
+      return $this->getOption('implicit', TRUE);
+    }
+
+    list($count) = explode("\t", reset($output));
+
+    if ($count > $this->getOption('threshold', 100)) {
+      $this->errors[$field_info['id']] = "{$field_instance_info['label']} ($count)";
+      return FALSE;
+    }
+
+    return TRUE;
+  }
+}

--- a/src/Check/D7/EntityReferenceAutocomplete.php
+++ b/src/Check/D7/EntityReferenceAutocomplete.php
@@ -65,7 +65,6 @@ class EntityReferenceAutocomplete extends Check {
       }
     }
 
-
     $this->setToken('num_fields', $valid);
     $this->setToken('num_plural', $valid > 1 ? 's' : '');
     $this->setToken('error_replace', implode(', ',  $this->errors));

--- a/src/Check/D7/EntityReferenceAutocomplete.php
+++ b/src/Check/D7/EntityReferenceAutocomplete.php
@@ -9,6 +9,7 @@ namespace SiteAudit\Check\D7;
 use SiteAudit\Check\Check;
 use SiteAudit\AuditResponse\AuditResponse;
 use SiteAudit\Annotation\CheckInfo;
+use SiteAudit\Executor\DoesNotApplyException;
 
 /**
  * @CheckInfo(
@@ -39,9 +40,9 @@ class EntityReferenceAutocomplete extends Check {
     $valid = 0;
 
     try {
-      $output = $this->context->drush->sqlQuery('SELECT fc.field_name, fc.data, fci.data FROM {field_config} fc JOIN {field_config_instance} fci ON fc.id = fci.field_id WHERE fc.type = \'entityreference\'');
+      $output = $this->context->drush->sqlQuery("SELECT fc.field_name, fc.data, fci.data FROM {field_config} fc JOIN {field_config_instance} fci ON fc.id = fci.field_id WHERE fc.type = 'entityreference'");
     } catch (\Exception $e) {
-      return AuditResponse::AUDIT_FAILURE;
+      throw new DoesNotApplyException;
     }
 
     foreach ($output as $line) {
@@ -124,7 +125,7 @@ class EntityReferenceAutocomplete extends Check {
     }
 
     try {
-      $output = $this->context->drush->sqlQuery('SELECT count(ttd.tid) as count FROM {taxonomy_term_data} ttd');
+      $output = $this->context->drush->sqlQuery("SELECT count(ttd.tid) as count FROM {taxonomy_term_data} ttd");
     } catch(\Exception $e) {
       return $this->getOption('implicit', TRUE);
     }
@@ -159,7 +160,7 @@ class EntityReferenceAutocomplete extends Check {
     $node_types = "'" . implode("','", $node_types) . "'";
 
     try {
-      $output = $this->context->drush->sqlQuery('SELECT count(node.nid) as count FROM {node} node WHERE node.type in (' . $node_types . ')');
+      $output = $this->context->drush->sqlQuery("SELECT count(node.nid) as count FROM {node} node WHERE node.type in (" . $node_types . ")");
     } catch (\Exception $e) {
       return $this->getOption('implicit', TRUE);
     }


### PR DESCRIPTION
- Updates `AudtiResponse.php` so remediation advice can use tokens
- Adds `EntityReferenceAutocomplete.php`

Recently I ran into an issue with a site that would cripple the server, basically when the entity reference field was loaded as a select list with > 100 references we see exponential degradation. It has a number of calls to render which can then expand into thousands of other calls based on the entities render function.

Some anecdotal stats:
- Referenced entities: 4796
- Time-to-first-byte 5.6mins

An interesting thing with this issue is that `php_max_execution` for the script was never reached so it would block a process for the entire duration. So I think that it is a valuable check to add for govcms checks given the shared resourcing.

The check will attempt to find entity reference fields that aren't configured as autocomplete fields and see if they're referencing content that has more than a threshold which we can control via the yml configs.