### PR TITLE
Explode view arguments for all content types

### DIFF
--- a/src/Check/D7/EntityReferenceAutocomplete.php
+++ b/src/Check/D7/EntityReferenceAutocomplete.php
@@ -122,7 +122,12 @@ class EntityReferenceAutocomplete extends Check {
       $args = array_keys($handler_settings['target_bundles']);
     }
     elseif (isset($handler_settings['view']['args'])) {
-      $args = $handler_settings['view']['args'];
+      $args = [];
+      foreach ($handler_settings['view']['args'] as $arg) {
+        // If we're using views we can pass multiple entity types in
+        // contextually separated by a +.
+        $args = array_merge($args, explode('+', $arg));
+      }
     }
 
     return $args;


### PR DESCRIPTION
- Updates the entity reference check so that it attempts to interrogate entity reference fields that are using views. It will now attempt to separate all content types passed in contextually to a view that is being used as the entity reference source.
\