### PR TITLE
Make D7 GA check more helpful. Fixes #81.

### DIFF
--- a/src/Check/D7/GA.php
+++ b/src/Check/D7/GA.php
@@ -50,7 +50,9 @@ class GA extends Check {
     $codesnippet_after = trim($this->getOption('codesnippet_after', ''));
     if (!empty($codesnippet_after)) {
       if ($codesnippet_after !== $googleanalytics_codesnippet_after) {
-        $errors[] = 'Code snippet after is not correct - <code>googleanalytics_codesnippet_after</code> is set to <code>' . $googleanalytics_codesnippet_after . '</code>';
+        $errors[] = 'Code snippet after is not correct - want ';
+        $errors[] = '"' . $codesnippet_after . '" but got ';
+        $errors[] = '"' . $googleanalytics_codesnippet_after . '"';
       }
     }
 

--- a/src/Check/D7/GA.php
+++ b/src/Check/D7/GA.php
@@ -51,8 +51,8 @@ class GA extends Check {
     if (!empty($codesnippet_after)) {
       if ($codesnippet_after !== $googleanalytics_codesnippet_after) {
         $errors[] = 'Code snippet after is not correct - want ';
-        $errors[] = '"' . $codesnippet_after . '" but got ';
-        $errors[] = '"' . $googleanalytics_codesnippet_after . '"';
+        $errors[] = '"<code>' . $codesnippet_after . '<code>" but got ';
+        $errors[] = '"<code>' . $googleanalytics_codesnippet_after . '<code>"';
       }
     }
 

--- a/src/Check/D7/GA.php
+++ b/src/Check/D7/GA.php
@@ -51,8 +51,8 @@ class GA extends Check {
     if (!empty($codesnippet_after)) {
       if ($codesnippet_after !== $googleanalytics_codesnippet_after) {
         $errors[] = 'Code snippet after is not correct - want ';
-        $errors[] = '"<code>' . $codesnippet_after . '<code>" but got ';
-        $errors[] = '"<code>' . $googleanalytics_codesnippet_after . '<code>"';
+        $errors[] = '<code>' . $codesnippet_after . '</code> but got ';
+        $errors[] = '<code>' . $googleanalytics_codesnippet_after . '</code>';
       }
     }
 


### PR DESCRIPTION
Make the D7 Google Analytics check more helpful by teaching it to tell you what it is looking for and what you have set at the moment.