### PR TITLE
Pattren maching updated to accomodate 9 digit Google Analytics account

### DIFF
--- a/profiles/govcms_saas.yml
+++ b/profiles/govcms_saas.yml
@@ -62,7 +62,7 @@ checks :
   \Drutiny\Check\D7\ImageDerivatives : {}
   \Drutiny\Check\D7\UserRegister : {}
   \Drutiny\Check\D7\GA :
-    account : '^UA-\d{7,8}-\d{1,2}$'
+    account : '^UA-\d{7,9}-\d{1,2}$'
     cache : '0'
     codesnippet_after : "ga('create', 'UA-54970022-1', 'auto', {'name': 'govcms'}); ga('govcms.send', 'pageview', {'anonymizeIp': true});"
   \Drutiny\Check\D7\NoAdministrators : {}

--- a/src/Check/D7/GA.php
+++ b/src/Check/D7/GA.php
@@ -37,7 +37,7 @@ class GA extends Check {
     $this->setToken('googleanalytics_codesnippet_after', $googleanalytics_codesnippet_after);
 
     $errors = [];
-    $pattern = $this->getOption('account', '^UA-\d{7,8}-\d{1,2}$');
+    $pattern = $this->getOption('account', '^UA-\d{7,9}-\d{1,2}$');
     if (!preg_match("#${pattern}#", $googleanalytics_account)) {
       $errors[] = 'Account does not match pattern - <code>googleanalytics_account</code> is set to <code>' . $googleanalytics_account . '</code>';
     }


### PR DESCRIPTION
With 9 digits in Google Analytics account audit script generates following error

`Google Analytics is not configured correctly. Account does not match pattern - googleanalytics_account is set to UA-xxxxxxxx-1`

