### PR TITLE
added new policy that checks for large files managed by Drupal

### DIFF
--- a/Policy/largeDrupalFiles.policy.yml
+++ b/Policy/largeDrupalFiles.policy.yml
@@ -1,0 +1,34 @@
+title: Large Drupal Files
+class: \Drutiny\Audit\Drupal\LargeDrupalFiles
+name: Drupal:largeFiles
+tags:
+  - Drupal 8
+  - Drupal 7
+description: |
+  Large static assets should be optimized for online display or ideally be housed in other services, e.g.
+    Amazon S3 (for files) or Youtube (for videos). Storing large files can consume storage volumes,
+    increase page load time and contribute to a higher than desired cache eviction rate.
+
+    This policy identifies files managed by Drupal that are larger than {{readable_max_size}}.
+remediation: |
+  Either delete the files if they are not needed, compress or optimize them,
+  or look to house them in a more appropriate location.success: No database updates required.
+success: No large files found.
+failure: |
+  **{{total}} Large Drupal file{{plural}} found**<br>
+  The table below contains the following data:
+      - **URI** - The path and filename.
+      - **Size** - The size of the file as reported by Drupal.
+      - **Used** - Determines if the file is associated with any content according to Drupal's file_usage table.
+
+  URI | Size | Used
+    --- | --- | ---
+    {{# files }}
+      {{uri}} | {{size}} | {{usage}}
+    {{/ files }}
+    {{too_many_files}}
+parameters:
+  max_size:
+    default: 20000000
+    description: 'Report files larger than this value measured in bytes.'
+    type: integer

--- a/src/Audit/Drupal/LargeDrupalFiles.php
+++ b/src/Audit/Drupal/LargeDrupalFiles.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Drutiny\Audit\Drupal;
+
+use Drutiny\Audit;
+use Drutiny\Sandbox\Sandbox;
+use Drutiny\AuditResponse\AuditResponse;
+
+/**
+ * Large files
+ */
+class LargeDrupalFiles extends Audit {
+
+  /**
+   * @inheritdoc
+   */
+  public function audit(Sandbox $sandbox) {
+    $max_size = (int) $sandbox->getParameter('max_size', 20000000);
+    $sandbox->setParameter('readable_max_size', $max_size / 1000 / 1000 . ' MB');
+    $query = "SELECT fm.uri, fm.filesize, (SELECT COUNT(*) FROM file_usage fu WHERE fu.fid = fm.fid) as 'usage' FROM file_managed fm WHERE fm.filesize >= @size ORDER BY fm.filesize DESC";
+    $query = strtr($query, ['@size' => $max_size]);
+    $output = $sandbox->drush()->sqlQuery($query);
+
+    if (empty($output)) {
+      return TRUE;
+    }
+
+    $records = explode("\n", $output);
+    $rows = array();
+    foreach ($records as $record) {
+      // Ignore record if it contains message about adding RSA key to known hosts.
+      if (strpos($record, '(RSA) to the list of known hosts') != FALSE) {
+        continue;
+      }
+
+      // Create the columns
+      $parts = explode("\t", $record);
+      $rows[] = [
+        'uri' => $parts[0],
+        'size' => number_format((float) $parts[1] / 1000 / 1000, 2) . ' MB',
+        'usage' => ($parts[2] == 0) ? 'No' : 'Yes'
+      ];
+    }
+    $totalRows = count($rows);
+    $sandbox->setParameter('total', $totalRows);
+
+    // Reduce the number of rows to 20
+    $rows = array_slice($rows, 0, 20);
+    $too_many_files = ($totalRows > 20) ? "Only the first 20 files are displayed." : "";
+
+    $sandbox->setParameter('too_many_files', $too_many_files);
+    $sandbox->setParameter('files', $rows);
+    $sandbox->setParameter('plural', $totalRows > 1 ? 's' : '');
+
+    return Audit::FAIL;
+  }
+
+}


### PR DESCRIPTION
This audit is similar to fs:largeFiles, but the main difference is instead of searching across the filesystem, it runs a query against the file_manged table. For sites that have large amounts of files, the fs:largeFiles can take a very long time and put stress on the FS. Drupal:largeFiles will also check the file_usage table and report if the large file is even being used in content. 