### PR TITLE
Added a new "Analysis" type report template.

### DIFF
--- a/src/Command/ProfileRunCommand.php
+++ b/src/Command/ProfileRunCommand.php
@@ -76,6 +76,15 @@ class ProfileRunCommand extends Command {
     // Setup the check.
     $profile = $input->getArgument('profile');
     $profiles = $registry->profiles();
+
+    // Grab the optional type variable from profile yml.
+    try {
+      $profile_type = $profiles[$profile]->get('type');
+    }
+    catch (\Exception $e) {
+      $profile_type = NULL;
+    }
+
     if (!isset($profiles[$profile])) {
       throw new InvalidArgumentException("$profile is not a valid profile.");
     }
@@ -156,7 +165,13 @@ class ProfileRunCommand extends Command {
           break;
 
         case 'html':
-          $report = new Report\ProfileRunHtmlReport($profiles[$profile], $sandbox->getTarget(), current($result));
+          if ($profile_type == 'analysis') {
+            $report = new Report\ProfileRunHtmlAnalysisReport($profiles[$profile], $sandbox->getTarget(), current($result));
+          }
+          else {
+            $report = new Report\ProfileRunHtmlReport($profiles[$profile], $sandbox->getTarget(), current($result));
+          }
+
           break;
 
         case 'console':

--- a/src/ProfileInformation.php
+++ b/src/ProfileInformation.php
@@ -12,6 +12,7 @@ use Symfony\Component\Validator\Mapping\ClassMetadata;
 class ProfileInformation {
 
   protected $title;
+  protected $type;
   protected $policies = [];
   protected $registry;
   protected $template = 'page';

--- a/src/Report/ProfileRunHtmlAnalysisReport.php
+++ b/src/Report/ProfileRunHtmlAnalysisReport.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Drutiny\Report;
+
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Drutiny\Registry;
+
+/**
+ *
+ */
+class ProfileRunHtmlAnalysisReport extends ProfileRunJsonReport {
+
+  /**
+   * @inheritdoc
+   */
+  public function render(InputInterface $input, OutputInterface $output) {
+    // Check YAML supports markdown and needs to be converted into HTML before
+    // we pass it into our report template.
+    $parsedown = new \Parsedown();
+
+    $render_vars = $this->getRenderVariables();
+
+    // Render any markdown into HTML for the report.
+    foreach ($render_vars['results'] as &$result) {
+      $result['description'] = $parsedown->text($result['description']);
+      $result['remediation'] = $parsedown->text($result['remediation']);
+      $result['success'] = $parsedown->text($result['success']);
+      $result['failure'] = $parsedown->text($result['failure']);
+      $result['warning'] = $parsedown->text($result['warning']);
+      $result['id'] = preg_replace('/[^0-9a-zA-Z]/', '', $result['title']);
+
+      $result['state_class'] = 'info';
+      if (!$result['is_notice'] && $result['status']) {
+        $result['state_class'] = 'success';
+      }
+      elseif ($result['is_not_applicable']) {
+        $result['state_class'] = 'default';
+      }
+      elseif (!$result['status']) {
+        $result['state_class'] = 'danger';
+      }
+      if ($result['has_warning']) {
+        $result['state_class'] = 'warning';
+      }
+    }
+
+    // Render the site report.
+    $content = $this->renderTemplate('analysis', $render_vars);
+
+    // Render the header/footer etc.
+    $render_vars['content'] = $content;
+    $content = $this->renderTemplate($this->info->get('template'), $render_vars);
+
+    // Hack to fix table styles in bootstrap theme.
+    $content = strtr($content, [
+      '<table>' => '<table class="table table-hover">'
+    ]);
+
+    $filename = $input->getOption('report-filename');
+    if ($filename == 'stdout') {
+      echo $content;
+      return;
+    }
+    if (file_put_contents($filename, $content)) {
+      $output->writeln('<info>Report written to ' . $filename . '</info>');
+    }
+    else {
+      echo $content;
+      $ouput->writeln('<error>Could not write to ' . $filename . '. Output to stdout instead.</error>');
+    }
+  }
+
+  /**
+   * Render an HTML template.
+   *
+   * @param string $tpl
+   *   The name of the .html.tpl template file to load for rendering.
+   * @param array $render_vars
+   *   An array of variables to be used within the template by the rendering engine.
+   */
+  public function renderTemplate($tpl, array $render_vars) {
+    $registry = new Registry();
+    $loader = new \Twig_Loader_Filesystem($registry->templateDirs());
+    $twig = new \Twig_Environment($loader, array(
+      'cache' => sys_get_temp_dir() . '/drutiny/cache',
+      'auto_reload' => TRUE,
+    ));
+    // $filter = new \Twig_SimpleFilter('filterXssAdmin', [$this, 'filterXssAdmin'], [
+    //   'is_safe' => ['html'],
+    // ]);
+    // $twig->addFilter($filter);
+    $template = $twig->load($tpl . '.html.twig');
+    $contents = $template->render($render_vars);
+    return $contents;
+  }
+
+}

--- a/src/Report/templates/analysis.html.twig
+++ b/src/Report/templates/analysis.html.twig
@@ -1,0 +1,111 @@
+<div class="container">
+  <!-- Example row of columns -->
+  <div class="row">
+
+    <div class="col-sm-12">
+      <h2>Contents</h2>
+      <p>This analysis report contains the following information:</p>
+      <ul class="list-group">
+        {% for policy_results in results %}
+          <li class="list-group-item list-group-item-action"><a href="#{{ policy_results.id }}">{{ policy_results.title }}</a></li>
+        {% endfor %}
+      </ul>
+    </div>
+  </div>
+
+
+  {% for result in results %}
+    {% if not result.is_not_applicable and result.is_notice %}
+      <!--- Policy Notice --->
+      <div class="row result-group">
+        <div class="col-sm-12">
+          <h2 id="{{ result.id }}">{{ result.title }}</h2>
+          <p>{{ result.description | raw }}</p>
+
+          <div class="panel panel-info">
+            <div class="panel-body">
+              {{ result.success | raw }}
+            </div>
+          </div>
+        </div>
+      </div>
+    {% elseif not result.is_not_applicable and result.status and not result.is_notice %}
+      <!--- Policy Pass --->
+      <div class="row result-group">
+        <div class="col-sm-12">
+          <h2 id="{{ result.id }}">{{ result.title }} <small class="label label-{{ result.state_class }}">{{ result.status_title }} <span class="glyphicon {% if result.status %}glyphicon-ok{% else %}glyphicon-remove{% endif %}" aria-hidden="true"></span></small></h2>
+          <p>{{ result.description | raw }}</p>
+
+          <div class="panel panel-success">
+            <div class="panel-heading">{{ result.status_title }}</div>
+            <div class="panel-body">
+              {{ result.success | raw }}
+
+              {% if result.has_warning %}
+                <div class="alert alert-warning" role="alert">
+                  {{ result.warning | raw }}
+                </div>
+              {% endif %}
+
+            </div>
+          </div>
+
+        </div>
+      </div>
+
+    {% elseif not result.is_not_applicable and not result.status and not result.has_error %}
+      <!--- Policy Failure --->
+      <div class="row result-group">
+        <div class="col-sm-12">
+          <h2 id="{{ result.id }}">{{ result.title }} <small class="label label-{{ result.state_class }}">{{ result.status_title }} <span class="glyphicon {% if result.status %}glyphicon-ok{% else %}glyphicon-remove{% endif %}" aria-hidden="true"></span></small></h2>
+          <p>{{ result.description | raw }}</p>
+          {% if result.has_warning %}
+            <div class="alert alert-warning" role="alert">
+              {{ result.warning | raw }}
+            </div>
+          {% endif %}
+
+          <div class="alert alert-{{ result.state_class }}" role="alert">
+            {{ result.failure | raw }}
+          </div>
+
+          <div class="panel panel-info">
+            <div class="panel-heading">Remediation</div>
+            <div class="panel-body">
+              {{ result.remediation | raw }}
+            </div>
+          </div>
+        </div>
+      </div>
+
+    {% elseif not result.is_not_applicable and not result.status and result.has_error %}
+      <!--- Policy Error --->
+      <div class="row result-group">
+        <div class="col-sm-12">
+          <h2 id="{{ result.id }}">{{ result.title }} <small class="label label-{{ result.state_class }}">{{ result.status_title }} <span class="glyphicon {% if result.status %}glyphicon-ok{% else %}glyphicon-remove{% endif %}" aria-hidden="true"></span></small></h2>
+          <p>{{ result.description | raw }}</p>
+          <div class="alert alert-{{ result.state_class }}" role="alert">
+            This policy was unable to determine the state of {{ domain }}.
+          </div>
+        </div>
+      </div>
+    {% elseif result.is_not_applicable %}
+      <!--- Policy Not Applicable --->
+      <div class="row result-group">
+        <div class="col-sm-12">
+          <h2 id="{{ result.id }}">{{ result.title }} <small class="label label-{{ result.state_class }}">{{ result.status_title }} <span class="glyphicon {% if result.status %}glyphicon-ok{% else %}glyphicon-remove{% endif %}" aria-hidden="true"></span></small></h2>
+          <p>{{ result.description | raw }}</p>
+          <div class="alert alert-{{ result.state_class }}" role="alert">
+            This policy is not applicable to {{ domain }}.
+          </div>
+        </div>
+      </div>
+    {% endif %}
+
+
+  {% endfor %}
+
+
+  <hr>
+
+</div>


### PR DESCRIPTION
There are two types of policies in the system now, analysis and audit. Currently, the HTML output is great for the audit type policies where there are displayed in a pass or fail format and the failed policies bubble to the top. That format doesn't quite work well for analytical policies where the data needs to be displayed for human analysis. 

This PR adds a new HTML template that is better suited for "analysis" reports. I have defined a new field in the profile.policy.yml file called "type". This field is optional and the values are `audit` or `analysis`. Well, actually the code only checks for the value analysis. If type is left out or is any other value besides analysis then the original template is used. 

I'm not sure if my approach for implementing this features is the best way, so feel free to suggest an alternate way to accomplish this. I also haven't accommodated the multisite report output, that perhaps can be later, I wanted to first get your take on the solution before I go any further. 