### PR TITLE
Use sa alias for site-alias command for drush9 compatibility.

### DIFF
--- a/src/Target/DrushTarget.php
+++ b/src/Target/DrushTarget.php
@@ -25,7 +25,7 @@ class DrushTarget extends Target implements DrushInterface, ExecInterface {
    */
   public function parse($target_data) {
     $this->alias = $target_data;
-    $data = $this->sandbox()->exec('drush site-alias @alias --format=json', [
+    $data = $this->sandbox()->exec('drush sa @alias --format=json', [
       '@alias' => $target_data,
     ]);
     $options = json_decode($data, TRUE);


### PR DESCRIPTION
The `DrushTarget` currently executes `drush site-alias`, which was re-written to `drush site:alias` for drush 9. This PR makes use of `drush sa` instead, where the `sa` alias is valid for drush9 and is backwards compatible.