### PR TITLE
Add code markdown to tables for formatting

### DIFF
--- a/src/Report/templates/markdown/appendix_table.markdown.twig
+++ b/src/Report/templates/markdown/appendix_table.markdown.twig
@@ -1,5 +1,7 @@
+```
 Policy | Severity | Audit
 ------ | -------- | -----
 {% for result in results %}
 {{ result.title }} | {{ result.severity }} | {{ result.status_title }}
 {% endfor %}
+```

--- a/src/Report/templates/markdown/severity_stats.markdown.twig
+++ b/src/Report/templates/markdown/severity_stats.markdown.twig
@@ -1,6 +1,8 @@
+```
 Severity | Pass | Fail | Error | Warning | Not Applicable
 -------- | ---- | ---- | ----- | ------- | --------------
 {% for severity, row in stats  %}
 {{ severity }} ({{ totals[severity] }}) | {% if row.success %}{{ (row.success / totals[severity] * 100) | round(2) }}% ({{ row.success }}){% else %} - {% endif %} | {% if row.failure %}{{ (row.failure / totals[severity] * 100) | round(2) }}% ({{ row.failure }}){% else %} - {% endif %} | {% if row.error %}{{ (row.error / totals[severity] * 100) | round(2) }}% ({{ row.error }}){% else %} - {% endif %} | {% if row.warning %}{{ (row.warning / totals[severity] * 100) | round(2) }}% ({{ row.warning }}){% else %} - {% endif %} | {% if row.not_applicable %}{{ (row.not_applicable / totals[severity] * 100) | round(2) }}% ({{ row.not_applicable }}){% else %} - {% endif %}
 
 {% endfor %}
+```

--- a/src/Report/templates/markdown/summary_table.markdown.twig
+++ b/src/Report/templates/markdown/summary_table.markdown.twig
@@ -1,5 +1,7 @@
+```
 Policy | Severity | Audit
 ------ | -------- | -----
 {% for result in results if result.has_warning or result.has_error or not result.status and not result.is_not_applicable %}
 {{ result.title }} | {{ result.severity }} | {{ result.status_title }}
 {% endfor %}
+```


### PR DESCRIPTION
This is to resolve issue #180 by adding the code markdown tag around the tables used in the markdown template. 

Tables now are keeping format when posting to Zendesk as a report.