### PR TITLE
Fixed version number for doctrine/annotations package.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "require": {
         "caseyamcl/toc": "~1.0",
         "composer/semver": "^1.4.2",
-        "doctrine/annotations": "^1.2",
+        "doctrine/annotations": "^v1.2",
         "erusev/parsedown": "^1.6.3",
         "fiasco/symfony-console-style-markdown": "~1.0",
         "mustache/mustache": "^2.11",


### PR DESCRIPTION
I was updating my local copy of Drutiny and was running into an error:

```
Loading composer repositories with package information
Installing dependencies (including require-dev) from lock file
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Installation request for drutiny/drutiny 2.1.x-dev -> satisfiable by drutiny/drutiny[2.1.x-dev].
    - drutiny/drutiny 2.1.x-dev requires doctrine/annotations ^1.2 -> no matching package found.
  Problem 2
    - drutiny/drutiny 2.1.x-dev requires doctrine/annotations ^1.2 -> no matching package found.
    - drutiny/sumologic 2.x-dev requires drutiny/drutiny 2.1.*@dev -> satisfiable by drutiny/drutiny[2.1.x-dev].
    - Installation request for drutiny/sumologic 2.x-dev -> satisfiable by drutiny/sumologic[2.x-dev].

Potential causes:
 - A typo in the package name
 - The package is not available in a stable-enough version according to your minimum-stability setting
   see <https://getcomposer.org/doc/04-schema.md#minimum-stability> for more details.
 - It's a private package and you forgot to add a custom repository to find it

Read <https://getcomposer.org/doc/articles/troubleshooting.md> for further common problems.
```

Upon checking the [packagist page](https://packagist.org/packages/doctrine/annotations) I noticed that this package has an unconventional version numbering scheme (e.g. "v1.2" as opposed to the usual "1.2").

This PR just fixes the typo.