### PR TITLE
Fix to allow formatTables function to be called during overrides

### DIFF
--- a/src/Report/Format/Markdown.php
+++ b/src/Report/Format/Markdown.php
@@ -133,7 +133,7 @@ class Markdown extends JSON {
     $render['content'] = $content;
     $content = $this->renderTemplate($this->getTemplate(), $render);
 
-    return self::formatTables($content);
+    return $this->formatTables($content);
   }
 
   public static function formatTables($markdown)


### PR DESCRIPTION
This corrects issue #184.

The processRender function will now allow formatTables to be overridden and called from other formatters.