### PR TITLE
Fix the parameter name in the example in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ The command above would audit the site that resolved to the `@drupalvm.dev` drus
 Some policies have parameters you can specify which can be passed in at call time. Use `policy:info` to find out more about the parameters available for a check.
 
 ```
-./vendor/bin/drutiny policy:audit -p max_age=600 Drupal-8:PageCacheExpiry @drupalvm.dev
+./vendor/bin/drutiny policy:audit -p value=600 Drupal-8:PageCacheExpiry @drupalvm.dev
 ```
 
 Audits are simple self contained classes that are simple to read and understand. Policies are simple YAML files that determine how to use Audit classes. Drutiny can be extended very easily to audit for your own unique requirements. Pull requests are welcome as well, please see the [contributing guide](https://drutiny.github.io/2.1.x/CONTRIBUTING/).
@@ -86,7 +86,7 @@ Audits are simple self contained classes that are simple to read and understand.
 Some checks have redemptive capability. Passing the `--remediate` flag into the call with "auto-heal" the site if the check fails on first pass.
 
 ```
-./vendor/bin/drutiny policy:audit -p max_age=600 --remediate Drupal-8:PageCacheExpiry @drupalvm.dev
+./vendor/bin/drutiny policy:audit -p value=600 --remediate Drupal-8:PageCacheExpiry @drupalvm.dev
 ```
 
 ### Running a profile of checks

--- a/src/Report/Format/JSON.php
+++ b/src/Report/Format/JSON.php
@@ -39,6 +39,7 @@ class JSON extends Format {
 
     // Report Title.
     $schema['title'] = $profile->getTitle();
+    $schema['profile'] = $profile->getName();
     $schema['domain'] = $target->uri();
     $schema['summary'] = $target->uri();
     $schema['description'] = $profile->getDescription();

--- a/src/Report/templates/html/script_footer.html.twig
+++ b/src/Report/templates/html/script_footer.html.twig
@@ -138,3 +138,32 @@
 
   })(jQuery);
 </script>
+<!-- Global site tag (gtag.js) - Google Analytics -->
+<!-- <script async src="https://www.googletagmanager.com/gtag/js?id=UA-120749223-1"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'UA-120749223-1', {
+    'page_title' : '{{ title | raw }} - {{ domain }}',
+    'page_path': '/profile/{{ profile }}/{{ domain }}'
+  });
+</script> -->
+
+<!-- Google Analytics -->
+<script>
+(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+
+ga('create', 'UA-120749223-1', 'auto');
+ga('set', 'checkProtocolTask', null);
+ga('set', 'validationTask	', null);
+ga('set', 'checkStorageTask', null);
+ga('send', 'pageview', '/profile/{{ profile }}/{{ domain }}', {
+  title: '{{ title | raw }} - {{ domain }}'
+});
+</script>
+<!-- End Google Analytics -->


### PR DESCRIPTION
The README uses the example of `-p max_age`

However, this appears to be incorrect. Based on `policy:info Drupal-8:PageCacheExpiry` the allowable parameters are

collection
key
value
comp_type

This could alternately fixed by changing the parameter name in the src from `key` to `max_age` ?