### PR TITLE
The example in the README uses incorrect parameter.

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ The command above would audit the site that resolved to the `@drupalvm.dev` drus
 Some policies have parameters you can specify which can be passed in at call time. Use `policy:info` to find out more about the parameters available for a check.
 
 ```
-./vendor/bin/drutiny policy:audit -p max_age=600 Drupal-8:PageCacheExpiry @drupalvm.dev
+./vendor/bin/drutiny policy:audit -p value=600 Drupal-8:PageCacheExpiry @drupalvm.dev
 ```
 
 Audits are simple self contained classes that are simple to read and understand. Policies are simple YAML files that determine how to use Audit classes. Drutiny can be extended very easily to audit for your own unique requirements. Pull requests are welcome as well, please see the [contributing guide](https://drutiny.github.io/2.1.x/CONTRIBUTING/).
@@ -86,7 +86,7 @@ Audits are simple self contained classes that are simple to read and understand.
 Some checks have redemptive capability. Passing the `--remediate` flag into the call with "auto-heal" the site if the check fails on first pass.
 
 ```
-./vendor/bin/drutiny policy:audit -p max_age=600 --remediate Drupal-8:PageCacheExpiry @drupalvm.dev
+./vendor/bin/drutiny policy:audit -p value=600 --remediate Drupal-8:PageCacheExpiry @drupalvm.dev
 ```
 
 ### Running a profile of checks


### PR DESCRIPTION
The README uses the example of `-p max_age`

However, this appears to be incorrect. Based on `policy:info Drupal-8:PageCacheExpiry` the allowable parameters are

collection
`key`
value
comp_type

