### PR TITLE
Adjusting heading semantics in order to fix #183.

### DIFF
--- a/src/Report/templates/html/data.html.twig
+++ b/src/Report/templates/html/data.html.twig
@@ -1,7 +1,7 @@
 
 <div class="row result-group">
   <div class="col-sm-12 col-md-10">
-    <h4 id="{{ result.id }}">{{ result.title }}</h4>
+    <h3 id="{{ result.id }}">{{ result.title }}</h3>
     <p>{{ result.description | raw }}</p>
     <div class="panel panel-info">
       <div class="panel-body">

--- a/src/Report/templates/html/notice.html.twig
+++ b/src/Report/templates/html/notice.html.twig
@@ -1,7 +1,7 @@
 
 <div class="row result-group">
   <div class="col-sm-12 col-md-10">
-    <h4 id="{{ result.id }}">{{ result.title }}</h4>
+    <h3 id="{{ result.id }}">{{ result.title }}</h3>
     <p>{{ result.description | raw }}</p>
     <div class="panel panel-info">
       <div class="panel-body">


### PR DESCRIPTION
The TOC generator requires heading tags to be in a consistent series. The TOC generator was adding empty items to the menu because the hierarchy was h1 > h2 > h4. Changing the h4 to h3 resulted in the menu being rendered properly.