### PR TITLE
Load policies and profiles from .drutiny home directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ The command above would audit the site that resolved to the `@drupalvm.dev` drus
 Some policies have parameters you can specify which can be passed in at call time. Use `policy:info` to find out more about the parameters available for a check.
 
 ```
-./vendor/bin/drutiny policy:audit -p value=600 Drupal-8:PageCacheExpiry @drupalvm.dev
+./vendor/bin/drutiny policy:audit -p max_age=600 Drupal-8:PageCacheExpiry @drupalvm.dev
 ```
 
 Audits are self-contained classes that are simple to read and understand. Policies are simple YAML files that determine how to use Audit classes. Therefore, Drutiny can be extended very easily to audit for your own unique requirements. Pull requests are welcome as well, please see the [contributing guide](https://drutiny.github.io/2.2.x/CONTRIBUTING/).
@@ -89,7 +89,7 @@ Audits are self-contained classes that are simple to read and understand. Polici
 Some checks have redemptive capability. Passing the `--remediate` flag into the call with "auto-heal" the site if the check fails on first pass.
 
 ```
-./vendor/bin/drutiny policy:audit -p value=600 --remediate Drupal-8:PageCacheExpiry @drupalvm.dev
+./vendor/bin/drutiny policy:audit -p max_age=600 --remediate Drupal-8:PageCacheExpiry @drupalvm.dev
 ```
 
 ### Running a profile of checks

--- a/src/PolicySource/LocalFs.php
+++ b/src/PolicySource/LocalFs.php
@@ -9,55 +9,58 @@ use Drutiny\Policy;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Yaml\Yaml;
 
-class LocalFs implements PolicySourceInterface {
+class LocalFs implements PolicySourceInterface
+{
 
   /**
    * {@inheritdoc}
    */
-  public function getName()
-  {
-    return 'localfs';
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function getList()
-  {
-    $cache = Container::cache($this->getName())->getItem('list');
-    if ($cache->isHit()) {
-      return $cache->get();
+    public function getName()
+    {
+        return 'localfs';
     }
-    $finder = new Finder();
-    $finder->files()
-      ->in('.')
-      ->name('*.policy.yml');
 
-    $list = [];
-    foreach ($finder as $file) {
-      $policy = Yaml::parse(file_get_contents($file->getRealPath()));
-      $policy['filepath'] = $file->getRealPath();
-      $list[$policy['name']] = $policy;
+  /**
+   * {@inheritdoc}
+   */
+    public function getList()
+    {
+        $cache = Container::cache($this->getName())->getItem('list');
+        if ($cache->isHit()) {
+            return $cache->get();
+        }
+
+        $directories = array('.', getenv('HOME') . '/.drutiny/');
+        $finder = new Finder();
+        $finder->files()
+        ->in($directories)
+        ->name('*.policy.yml');
+
+        $list = [];
+        foreach ($finder as $file) {
+            $policy = Yaml::parse(file_get_contents($file->getRealPath()));
+            $policy['filepath'] = $file->getRealPath();
+            $list[$policy['name']] = $policy;
+        }
+        Container::cache($this->getName())->save(
+            $cache->set($list)->expiresAfter(3600)
+        );
+        return $list;
     }
-    Container::cache($this->getName())->save(
-      $cache->set($list)->expiresAfter(3600)
-    );
-    return $list;
-  }
 
   /**
    * {@inheritdoc}
    */
-  public function load(array $definition)
-  {
-    return new Policy($definition);
-  }
+    public function load(array $definition)
+    {
+        return new Policy($definition);
+    }
 
   /**
    * {@inheritdoc}
    */
-  public function getWeight()
-  {
-    return -10;
-  }
+    public function getWeight()
+    {
+        return -10;
+    }
 }

--- a/src/PolicySource/LocalFs.php
+++ b/src/PolicySource/LocalFs.php
@@ -14,52 +14,50 @@ class LocalFs implements PolicySourceInterface {
   /**
    * {@inheritdoc}
    */
-    public function getName()
-    {
-        return 'localfs';
-    }
+  public function getName()
+  {
+    return 'localfs';
+  }
 
   /**
    * {@inheritdoc}
    */
-    public function getList()
-    {
-        $cache = Container::cache($this->getName())->getItem('list');
-        if ($cache->isHit()) {
-            return $cache->get();
-        }
-
-        $directories = array('.', getenv('HOME') . '/.drutiny/');
-        $finder = new Finder();
-        $finder->files()
-        ->in($directories)
-        ->name('*.policy.yml');
-
-        $list = [];
-        foreach ($finder as $file) {
-            $policy = Yaml::parse(file_get_contents($file->getRealPath()));
-            $policy['filepath'] = $file->getRealPath();
-            $list[$policy['name']] = $policy;
-        }
-        Container::cache($this->getName())->save(
-            $cache->set($list)->expiresAfter(3600)
-        );
-        return $list;
+  public function getList()
+  {
+    $cache = Container::cache($this->getName())->getItem('list');
+    if ($cache->isHit()) {
+      return $cache->get();
     }
+    $finder = new Finder();
+    $finder->files()
+      ->in('.')
+      ->name('*.policy.yml');
+
+    $list = [];
+    foreach ($finder as $file) {
+      $policy = Yaml::parse(file_get_contents($file->getRealPath()));
+      $policy['filepath'] = $file->getRealPath();
+      $list[$policy['name']] = $policy;
+    }
+    Container::cache($this->getName())->save(
+      $cache->set($list)->expiresAfter(3600)
+    );
+    return $list;
+  }
 
   /**
    * {@inheritdoc}
    */
-    public function load(array $definition)
-    {
-        return new Policy($definition);
-    }
+  public function load(array $definition)
+  {
+    return new Policy($definition);
+  }
 
   /**
    * {@inheritdoc}
    */
-    public function getWeight()
-    {
-        return -10;
-    }
+  public function getWeight()
+  {
+    return -10;
+  }
 }

--- a/src/PolicySource/LocalFs.php
+++ b/src/PolicySource/LocalFs.php
@@ -28,9 +28,11 @@ class LocalFs implements PolicySourceInterface {
     if ($cache->isHit()) {
       return $cache->get();
     }
+
+    $directories = array('.', getenv('HOME') . '/.drutiny/');
     $finder = new Finder();
     $finder->files()
-      ->in('.')
+      ->in($directories)
       ->name('*.policy.yml');
 
     $list = [];

--- a/src/PolicySource/LocalFs.php
+++ b/src/PolicySource/LocalFs.php
@@ -9,8 +9,7 @@ use Drutiny\Policy;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Yaml\Yaml;
 
-class LocalFs implements PolicySourceInterface
-{
+class LocalFs implements PolicySourceInterface {
 
   /**
    * {@inheritdoc}

--- a/src/Profile/ProfileSourceLocalFs.php
+++ b/src/Profile/ProfileSourceLocalFs.php
@@ -28,9 +28,11 @@ class ProfileSourceLocalFs implements ProfileSourceInterface {
     if ($cache->isHit()) {
       return $cache->get();
     }
+
+    $directories = array('.', getenv('HOME') . '/.drutiny/');
     $finder = new Finder();
     $finder->files()
-      ->in('.')
+      ->in($directories)
       ->name('*.profile.yml');
 
     $list = [];

--- a/src/Profile/ProfileSourceLocalFs.php
+++ b/src/Profile/ProfileSourceLocalFs.php
@@ -9,58 +9,61 @@ use Drutiny\Profile;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Yaml\Yaml;
 
-class ProfileSourceLocalFs implements ProfileSourceInterface {
+class ProfileSourceLocalFs implements ProfileSourceInterface
+{
 
   /**
    * {@inheritdoc}
    */
-  public function getName()
-  {
-    return 'localfs';
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function getList()
-  {
-    $cache = Container::cache($this->getName())->getItem('profiles');
-    if ($cache->isHit()) {
-      return $cache->get();
+    public function getName()
+    {
+        return 'localfs';
     }
-    $finder = new Finder();
-    $finder->files()
-      ->in('.')
-      ->name('*.profile.yml');
 
-    $list = [];
-    foreach ($finder as $file) {
-      $name = str_replace('.profile.yml', '', pathinfo($file->getRealPath(), PATHINFO_BASENAME));
-      $profile = Yaml::parse(file_get_contents($file->getRealPath()));
-      $profile['filepath'] = $file->getRealPath();
-      $profile['name'] = $name;
-      unset($profile['format']);
-      $list[$name] = $profile;
+  /**
+   * {@inheritdoc}
+   */
+    public function getList()
+    {
+        $cache = Container::cache($this->getName())->getItem('profiles');
+        if ($cache->isHit()) {
+            return $cache->get();
+        }
+
+        $directories = array('.', getenv('HOME') . '/.drutiny/');
+        $finder = new Finder();
+        $finder->files()
+        ->in($directories)
+        ->name('*.profile.yml');
+
+        $list = [];
+        foreach ($finder as $file) {
+            $name = str_replace('.profile.yml', '', pathinfo($file->getRealPath(), PATHINFO_BASENAME));
+            $profile = Yaml::parse(file_get_contents($file->getRealPath()));
+            $profile['filepath'] = $file->getRealPath();
+            $profile['name'] = $name;
+            unset($profile['format']);
+            $list[$name] = $profile;
+        }
+        Container::cache($this->getName())->save(
+            $cache->set($list)->expiresAfter(3600)
+        );
+        return $list;
     }
-    Container::cache($this->getName())->save(
-      $cache->set($list)->expiresAfter(3600)
-    );
-    return $list;
-  }
 
   /**
    * {@inheritdoc}
    */
-  public function load(array $definition)
-  {
-    return Profile::loadFromFile($definition['filepath']);
-  }
+    public function load(array $definition)
+    {
+        return Profile::loadFromFile($definition['filepath']);
+    }
 
   /**
    * {@inheritdoc}
    */
-  public function getWeight()
-  {
-    return -10;
-  }
+    public function getWeight()
+    {
+        return -10;
+    }
 }

--- a/src/Profile/ProfileSourceLocalFs.php
+++ b/src/Profile/ProfileSourceLocalFs.php
@@ -9,8 +9,7 @@ use Drutiny\Profile;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Yaml\Yaml;
 
-class ProfileSourceLocalFs implements ProfileSourceInterface
-{
+class ProfileSourceLocalFs implements ProfileSourceInterface {
 
   /**
    * {@inheritdoc}

--- a/src/Profile/ProfileSourceLocalFs.php
+++ b/src/Profile/ProfileSourceLocalFs.php
@@ -14,55 +14,53 @@ class ProfileSourceLocalFs implements ProfileSourceInterface {
   /**
    * {@inheritdoc}
    */
-    public function getName()
-    {
-        return 'localfs';
-    }
+  public function getName()
+  {
+    return 'localfs';
+  }
 
   /**
    * {@inheritdoc}
    */
-    public function getList()
-    {
-        $cache = Container::cache($this->getName())->getItem('profiles');
-        if ($cache->isHit()) {
-            return $cache->get();
-        }
-
-        $directories = array('.', getenv('HOME') . '/.drutiny/');
-        $finder = new Finder();
-        $finder->files()
-        ->in($directories)
-        ->name('*.profile.yml');
-
-        $list = [];
-        foreach ($finder as $file) {
-            $name = str_replace('.profile.yml', '', pathinfo($file->getRealPath(), PATHINFO_BASENAME));
-            $profile = Yaml::parse(file_get_contents($file->getRealPath()));
-            $profile['filepath'] = $file->getRealPath();
-            $profile['name'] = $name;
-            unset($profile['format']);
-            $list[$name] = $profile;
-        }
-        Container::cache($this->getName())->save(
-            $cache->set($list)->expiresAfter(3600)
-        );
-        return $list;
+  public function getList()
+  {
+    $cache = Container::cache($this->getName())->getItem('profiles');
+    if ($cache->isHit()) {
+      return $cache->get();
     }
+    $finder = new Finder();
+    $finder->files()
+      ->in('.')
+      ->name('*.profile.yml');
+
+    $list = [];
+    foreach ($finder as $file) {
+      $name = str_replace('.profile.yml', '', pathinfo($file->getRealPath(), PATHINFO_BASENAME));
+      $profile = Yaml::parse(file_get_contents($file->getRealPath()));
+      $profile['filepath'] = $file->getRealPath();
+      $profile['name'] = $name;
+      unset($profile['format']);
+      $list[$name] = $profile;
+    }
+    Container::cache($this->getName())->save(
+      $cache->set($list)->expiresAfter(3600)
+    );
+    return $list;
+  }
 
   /**
    * {@inheritdoc}
    */
-    public function load(array $definition)
-    {
-        return Profile::loadFromFile($definition['filepath']);
-    }
+  public function load(array $definition)
+  {
+    return Profile::loadFromFile($definition['filepath']);
+  }
 
   /**
    * {@inheritdoc}
    */
-    public function getWeight()
-    {
-        return -10;
-    }
+  public function getWeight()
+  {
+    return -10;
+  }
 }


### PR DESCRIPTION
While writing new policies and profiles I'd like to be able to update Drutiny without having to move these files around.  Being able to load them from my .drutiny directory seems like a good way around this.