### PR TITLE
Update timezone detection to support 3-level timezones

### DIFF
--- a/bin/drutiny
+++ b/bin/drutiny
@@ -3,26 +3,19 @@
 
 use Symfony\Component\Console\Application;
 use Drutiny\CommandDiscovery;
-use Composer\Autoload\ClassLoader;
 use Doctrine\Common\Annotations\AnnotationRegistry;
+
+$timezone = 'UTC';
 
 // Set the timezone to the local OS if supported.
 if (file_exists('/etc/localtime')) {
   $systemZoneName = readlink('/etc/localtime');
-  $city = basename($systemZoneName);
-  if ($city == 'UTC') {
-    $systemZoneName = $city;
+  if (strpos($systemZoneName, 'zoneinfo') !== FALSE) {
+    $timezone = substr($systemZoneName, strpos($systemZoneName, 'zoneinfo') + 9);
   }
-  else {
-    $country = basename(dirname($systemZoneName));
-    $systemZoneName = implode('/', [$country, $city]);
-  }
-  date_default_timezone_set($systemZoneName);
 }
-// Fallback to UTC.
-else {
-  date_default_timezone_set('UTC');
-}
+
+date_default_timezone_set($timezone);
 
 /**
  * @var ClassLoader $loader


### PR DESCRIPTION
Not all timezone database ids have one or two parts (i.e. `UTC` or `America/New_York`), causing the previous timezone detection to fail with the following error when using a timezone like `America/Indiana/Indianapolis`: 

```
PHP Notice:  date_default_timezone_set(): Timezone ID 'Indiana/Indianapolis' is invalid in ./bin/drutiny on line 20
```

Instead of using `dirname()` to pull off the last two elements of `$systemZoneName`, I updated the logic to search that string for the `zoneinfo`, which should be the last element prior to the actual timezone id, then return the string with everything up to (and including) that element removed.

Tested as working on MacOS 10.13.6, should be compatible with older version of MacOS and Ubuntu/Debian based Linux.