### PR TITLE
Fixed correct report URI when using ReportPerSite option

### DIFF
--- a/src/Assessment.php
+++ b/src/Assessment.php
@@ -106,6 +106,16 @@ class Assessment {
   {
     return $this->results;
   }
+
+  /**
+   * Get the uri of Assessment object.
+   *
+   * @return string uri.
+   */
+  public function uri()
+  {
+    return $this->uri;
+  }
 }
 
  ?>

--- a/src/Report/Format/JSON.php
+++ b/src/Report/Format/JSON.php
@@ -44,8 +44,8 @@ class JSON extends Format {
     // Report Title.
     $schema['title'] = $profile->getTitle();
     $schema['profile'] = $profile->getName();
-    $schema['domain'] = $target->uri();
-    $schema['summary'] = $target->uri();
+    $schema['domain'] = $profile->reportPerSite() === true ? $assessment->uri() : $target->uri();
+    $schema['summary'] = $profile->reportPerSite() === true ? $assessment->uri() : $target->uri();
     $schema['description'] = $profile->getDescription();
     $schema['remediations'] = [];
     $schema['reporting_period_start'] = $profile->getReportingPeriodStart()->format('Y-m-d H:i:s e');

--- a/src/Report/Format/JSON.php
+++ b/src/Report/Format/JSON.php
@@ -44,8 +44,8 @@ class JSON extends Format {
     // Report Title.
     $schema['title'] = $profile->getTitle();
     $schema['profile'] = $profile->getName();
-    $schema['domain'] = $profile->reportPerSite() === true ? $assessment->uri() : $target->uri();
-    $schema['summary'] = $profile->reportPerSite() === true ? $assessment->uri() : $target->uri();
+    $schema['domain'] = $assessment->uri();
+    $schema['summary'] = $assessment->uri();
     $schema['description'] = $profile->getDescription();
     $schema['remediations'] = [];
     $schema['reporting_period_start'] = $profile->getReportingPeriodStart()->format('Y-m-d H:i:s e');


### PR DESCRIPTION
Wrong current URI was shown in reports when using option --report-per-site.

Actually this part of code above, is always pushing the last $uri of $uris array in $target->uri, resulting in the same domain showing up on every report.

This fix sets the value to ```$assessment->uri``` if "reportPerSite" option is used.

```
foreach ($uris as $uri) {
      try {
        $target->setUri($uri);
      }
      catch (\Drutiny\Target\InvalidTargetException $e) {
        Container::getLogger()->warning("Target cannot be evaluated: " . $e->getMessage());
        $progress->advance(count($policyDefinitions));
        continue;
      }

      $assessment = new Assessment($uri);
      $assessment->assessTarget($target, $policies, $start, $end, $input->getOption('remediate'));
      $results[$uri] = $assessment;
    }
```
