### PR TITLE
First pass of exit code implementation.

### DIFF
--- a/src/Assessment.php
+++ b/src/Assessment.php
@@ -18,6 +18,29 @@ class Assessment {
    */
   protected $results = [];
 
+  /**
+   * @var int exitcode
+   */
+  protected $exitcode = 0;
+
+  /**
+   * Returns to validated exit code from the assessment.
+   *
+   * @return int
+   */
+  public function getExitCode() {
+    return $this->exitcode;
+  }
+
+  /**
+   * Sets a exitcode for this assessment.
+   *
+   * @param int $exitcode
+   */
+  public function setExitCode($exitcode = 0) {
+    $this->exitcode = $exitcode;
+  }
+
   public function __construct($uri = 'default')
   {
     $this->uri = $uri;
@@ -65,6 +88,10 @@ class Assessment {
 
       if ($is_progress_bar) {
         $log->advance();
+      }
+
+      if (!$response->isSuccessful() && $response->getSeverity() === 'critical') {
+        $this->setExitCode(1);
       }
     }
 

--- a/src/Audit/Drupal/ModuleEnabled.php
+++ b/src/Audit/Drupal/ModuleEnabled.php
@@ -40,7 +40,7 @@ class ModuleEnabled extends Audit implements RemediableInterface {
   {
     $module = $sandbox->getParameter('module');
     $sandbox->drush()->en($module, '-y');
-    return $this->check($sandbox);
+    return $this->audit($sandbox);
   }
 
 }

--- a/src/Audit/Drupal/ModuleEnabled.php
+++ b/src/Audit/Drupal/ModuleEnabled.php
@@ -40,7 +40,7 @@ class ModuleEnabled extends Audit implements RemediableInterface {
   {
     $module = $sandbox->getParameter('module');
     $sandbox->drush()->en($module, '-y');
-    return $this->audit($sandbox);
+    return $this->check($sandbox);
   }
 
 }

--- a/src/Command/ProfileRunCommand.php
+++ b/src/Command/ProfileRunCommand.php
@@ -272,5 +272,7 @@ class ProfileRunCommand extends Command {
     foreach ($files as $filepath) {
       $console->success('Report written to ' . $filepath);
     }
+
+    exit($assessment->getExitCode());
   }
 }

--- a/src/Command/ProfileRunCommand.php
+++ b/src/Command/ProfileRunCommand.php
@@ -25,6 +25,7 @@ use Symfony\Component\Console\Style\SymfonyStyle;
  *
  */
 class ProfileRunCommand extends Command {
+  use \Drutiny\Policy\ContentSeverityTrait;
 
   /**
    * @inheritdoc
@@ -70,6 +71,13 @@ class ProfileRunCommand extends Command {
         InputOption::VALUE_OPTIONAL,
         'Override the title of the profile with the specified value.',
         false
+      )
+      ->addOption(
+        'exit-on-severity',
+        'x',
+        InputOption::VALUE_OPTIONAL,
+        'Send an exit code to the console if a policy of a given severity fails. Defaults to none (exit code 0). (Options: none, low, normal, high, critical)',
+        'none'
       )
       ->addOption(
         'report-filename',
@@ -273,6 +281,33 @@ class ProfileRunCommand extends Command {
       $console->success('Report written to ' . $filepath);
     }
 
-    exit($assessment->getExitCode());
+    $this->setSeverity($input->getOption('exit-on-severity'));
+
+    // Do not use a non-zero exit code when no severity is set (Default).
+    if (!$this->getSeverity()) {
+      return;
+    }
+
+    $bad_results = 0;
+
+    foreach ($results as $assessment) {
+      if ($assessment->isSuccessful()) {
+        continue;
+      }
+
+      // Increase the exit severity to match the highest assessment severity.
+      if ($assessment->getSeverity() >= $this->getSeverity()) {
+        $this->setSeverity($assessment->getSeverity());
+        $bad_results++;
+      }
+    }
+
+    // Zero exit code when no bad results.
+    if (!$bad_results) {
+      return;
+    }
+
+    // Return the highest found severity as exit code.
+    return $this->getSeverity();
   }
 }


### PR DESCRIPTION
This is a first pass at getting exit codes implemented which allows for future compatibility for expansion of this feature if ever considered.

It provides a new variable available to the `Assessment` with a getter and setter, and provides one condition where the default value `0` is changed to `1`, so the code will always execute and complete with exit code `0` unless configured to use a different exit code.

Feedback is appreciated, hopefully it lines up well enough with the discussion in #211.