### PR TITLE
Fix multipath based domains filenames

### DIFF
--- a/src/Report/Format.php
+++ b/src/Report/Format.php
@@ -66,6 +66,8 @@ abstract class Format {
         foreach ($results as $uri => $result) {
           $variables = $this->preprocessResult($profile, $target, $result);
 
+          // Some website uri may contain slashes, ex http://domain.com/path1/path2/
+          // Uri is used to generate the filepath, slashes must be replaced to avoid conflict
           $info['uri'] = str_replace("/", "_", $uri);
           $filepath = strtr('dirname/filename/uri.extension', $info);
 

--- a/src/Report/Format.php
+++ b/src/Report/Format.php
@@ -66,7 +66,7 @@ abstract class Format {
         foreach ($results as $uri => $result) {
           $variables = $this->preprocessResult($profile, $target, $result);
 
-          $info['uri'] = $uri;
+          $info['uri'] = str_replace("/", "_", $uri);
           $filepath = strtr('dirname/filename/uri.extension', $info);
 
           // Ensure the directory is available or continue.


### PR DESCRIPTION
In some cases, like multipath based domains (domain.com/path1/path2 ...), all the slashes contained in the uri conflict with filename, so reports cannot be written. This PR address this point by changing slashes to underscores in report filenames.

Can be reproduced by using --report-per-site option and any multipath based domain.