### PR TITLE
Ensure remote execution doesn't fallthrough and make a secondary call…

### DIFF
--- a/src/Target/DrushTarget.php
+++ b/src/Target/DrushTarget.php
@@ -70,7 +70,7 @@ class DrushTarget extends Target implements DrushTargetInterface, DrushExecutabl
     // Do not use a locally sourced alias if the command will be executed remotely.
     if (isset($this->options['remote-host'])) {
       $parameters['@root'] = $this->options['root'];
-      $this->exec('@pipe @drush -r @root @options @method @args', $parameters);
+      return $this->exec('@pipe @drush -r @root @options @method @args', $parameters);
     }
     return $this->exec('@pipe @drush @alias @options @method @args', $parameters);
   }


### PR DESCRIPTION
Fixes #227.

Drutiny expects a return value to start a process for Drush, but when remote execution evaluates it will afterwards fall-through and continue execution even if that means the commands continue to fail the audit/policy.

Behavior is consistent with the existing behavior when using Drush aliases without a `remote-host` property.