### PR TITLE
Add --dev to composer require drutiny/plugin-drupal-8 in readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ $ composer search drutiny
 For Drupal 8 sites, `drutiny/plugin-drupal-8` would be a good plugin to add.
 
 ```
-$ composer require drutiny/plugin-drupal-8 2.x-dev
+$ composer require --dev drutiny/plugin-drupal-8 2.x-dev
 ```
 
 ### Running an Audit


### PR DESCRIPTION
Readme says to install Drutiny with `composer require --dev drutiny/drutiny 2.3.*@dev` mentioning "Drutiny is a require-dev type dependency."

Later on, It says to `composer require drutiny/plugin-drupal-8 2.x-dev` which I think is missing the `--dev` option. As this will technically move `drutiny/drutiny` "silently" into the "require" section as a dependency.

PR fixes that step in the readme.