### PR TITLE
Revise duration calculation to include months.

### DIFF
--- a/src/Sandbox/ReportingPeriodTrait.php
+++ b/src/Sandbox/ReportingPeriodTrait.php
@@ -76,6 +76,8 @@ trait ReportingPeriodTrait {
                + ($interval->h * 3600)
                // days to seconds
                + ($interval->d * 86400)
+               // months to seconds
+               + ($interval->m * 2592000)
                // years to seconds
                + ($interval->y * 31536000);
      return $seconds;


### PR DESCRIPTION
The diff in getReportingPeriodInterval can return months (m) in its result, which is not currently captured in the conversion to seconds. This can lead to an interval incorrectly being set to zero, causing the reporting period step duration to revert to the default 30 seconds. This, in turn, causes data tables to be generated with many more rows than expected, which affects graphing performance and legibility.

See issue #241 for more information.