### PR TITLE
Allow console to display all columns of tabular data.

### DIFF
--- a/src/Report/Format/Console.php
+++ b/src/Report/Format/Console.php
@@ -36,7 +36,7 @@ class Console extends Format {
           $summary[] = $line;
           continue;
         }
-        $words = explode(' ', $line);
+        $words = preg_split('/ +/', $line);
         $phrase = [];
         while ($word = array_shift($words)) {
           $compound_line = $phrase;

--- a/src/Sandbox/ReportingPeriodTrait.php
+++ b/src/Sandbox/ReportingPeriodTrait.php
@@ -76,6 +76,8 @@ trait ReportingPeriodTrait {
                + ($interval->h * 3600)
                // days to seconds
                + ($interval->d * 86400)
+               // months to seconds
+               + ($interval->m * 2592000)
                // years to seconds
                + ($interval->y * 31536000);
      return $seconds;


### PR DESCRIPTION
Addresses issue #243. When outputting to console, tabular results are getting truncated. This occurs because the results table contains multiple consecutive space characters, representing an empty table cell. The results preprocessor broke lines into words expecting a single space character. When it encountered two or more spaces, it stopped processing the string, and cut off the remaining text. This change accommodates multiple consecutive spaces, thereby allowing the full data row to be displayed in the console. 

Example below is output from `cloudflare:http_status` policy.

Before:
<img width="733" alt="Screen Shot 2020-05-15 at 11 22 35" src="https://user-images.githubusercontent.com/3334926/82087702-7b434d80-96a5-11ea-83b8-b5f9968c50bf.png">

After:
<img width="759" alt="Screen Shot 2020-05-15 at 11 52 12" src="https://user-images.githubusercontent.com/3334926/82087897-dd03b780-96a5-11ea-9a1e-ababe3c78aaf.png">

