### PR TITLE
Revise reporting period intervals and calculation of steps

### DIFF
--- a/src/Sandbox/ReportingPeriodTrait.php
+++ b/src/Sandbox/ReportingPeriodTrait.php
@@ -101,6 +101,7 @@ trait ReportingPeriodTrait {
         10800, // 3 hours
         18000, // 5 hours
         21600, // 6 hours
+        28800, // 8 hours
         43200, // 12 hours
         86400, // 1 day
         172800, // 2 days

--- a/src/Sandbox/ReportingPeriodTrait.php
+++ b/src/Sandbox/ReportingPeriodTrait.php
@@ -92,6 +92,7 @@ trait ReportingPeriodTrait {
         30, // 30 seconds
         60, // 1 minute
         120, // 2 minutes
+        180, // 3 minutes
         300, // 5 minutes
         600, // 10 minutes
         900, // 15 minutes
@@ -99,12 +100,13 @@ trait ReportingPeriodTrait {
         3600, // 1 hour
         7200, // 2 hours
         10800, // 3 hours
-        18000, // 5 hours
+        14400, // 4 hours
         21600, // 6 hours
         28800, // 8 hours
         43200, // 12 hours
         86400, // 1 day
         172800, // 2 days
+        259200, // 3 days
         432000, // 5 days
         604800, // 7 days
       ];
@@ -120,14 +122,14 @@ trait ReportingPeriodTrait {
       $duration = $this->getReportingPeriodDuration();
 
       $steps = array_map(function ($interval) use ($duration) {
-        return (int) round($duration / $interval);
+        return (int) ceil($duration / $interval);
       }, $this->_getReportingPeriodIntervals());
 
       $steps = array_combine($this->_getReportingPeriodIntervals(), $steps);
 
       $steps = array_filter($steps, function ($step) {
-        // 60 < X > 100;
-        return $step >= 60 && $step <= 100;
+        // Filter intervals to those resulting in 51 to 100 steps.
+        return $step > 50 && $step <= 100;
       });
 
       if (empty($steps)) {
@@ -139,6 +141,7 @@ trait ReportingPeriodTrait {
         throw new \Exception("Could not find a number of steps suitable for reporting period.");
       }
 
+      // Return the key from the first element in the steps array, which should be the largest number of steps.
       return key($steps);
     }
 


### PR DESCRIPTION
Addresses issue #246. Revised and introduced new reporting period intervals to ensure maximum 2:1 ratio from one to the next, and yield even division into larger time units. This, along with modifying the reporting period step calculation, is intended to eliminate situation where a "suitable number" of steps cannot be calculated from a report period. As there is the possibility of having _more than 1_ applicable interval, we favor the interval that results in the largest number of steps > 51 and ≤ 100. 

Example running `drutinycs policy:audit AcquiaCS:SumoLogic:PHPMemoryUsageTimeSeries @drupalvm.dev --reporting-period-start 2020-04-23 --reporting-period-end 2020-05-21`

Before:
<img width="888" alt="Screen Shot 2020-05-21 at 09 51 39" src="https://user-images.githubusercontent.com/3334926/82584698-b2a07700-9b49-11ea-97c1-03da42f48126.png">

After:
<img width="1038" alt="Screen Shot 2020-05-21 at 10 03 11" src="https://user-images.githubusercontent.com/3334926/82585127-60138a80-9b4a-11ea-8b7a-18763b6604e4.png">
