### PR TITLE
Drush 9 local support

### DIFF
--- a/src/Command/PolicyAuditCommand.php
+++ b/src/Command/PolicyAuditCommand.php
@@ -43,6 +43,12 @@ class PolicyAuditCommand extends AbstractReportingCommand {
         'The target to run the check against.'
       )
       ->addOption(
+        'root',
+        null,
+        InputOption::VALUE_OPTIONAL,
+        'Root path for the Drush alias.'
+      )
+      ->addOption(
         'set-parameter',
         'p',
         InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY,
@@ -111,6 +117,7 @@ class PolicyAuditCommand extends AbstractReportingCommand {
     // Setup the target.
     $target = TargetRegistry::loadTarget($input->getArgument('target'));
     $target->setUri($input->getOption('uri'));
+    $target->setRoot($input->getOption('root'));
 
     $assessment = new Assessment($input->getOption('uri'));
     $result = [];

--- a/src/Command/ProfileRunCommand.php
+++ b/src/Command/ProfileRunCommand.php
@@ -43,6 +43,12 @@ class ProfileRunCommand extends AbstractReportingCommand {
         'The target to run the policy collection against.'
       )
       ->addOption(
+        'root',
+        null,
+        InputOption::VALUE_OPTIONAL,
+        'Root path for the Drush alias.'
+      )
+      ->addOption(
         'remediate',
         'r',
         InputOption::VALUE_NONE,
@@ -181,6 +187,7 @@ class ProfileRunCommand extends AbstractReportingCommand {
 
     // Setup the target.
     $target = TargetRegistry::loadTarget($input->getArgument('target'));
+    $target->setRoot($input->getOption('root'));
 
     // Get the URLs.
     $uris = $input->getOption('uri');

--- a/src/Target/Target.php
+++ b/src/Target/Target.php
@@ -52,6 +52,16 @@ abstract class Target implements TargetInterface {
   }
 
   /**
+   * Set root option.
+   */
+  final public function setRoot($root) {
+    if (!empty($root)) {
+      $this->options['root'] = $root;
+    }
+    return $this;
+  }
+
+  /**
    * @inheritdoc
    * Implements ExecInterface::exec().
    */


### PR DESCRIPTION
Running policy:audit or profile:run commands from local Drush 9 alias gives following error:
```
[error] The Drush launcher could not find a Drupal site to operate on. Please do *one* of the following:
  - Navigate to any where within your Drupal project and try again.
  - Add --root=/path/to/drupal so Drush knows where your site is located.
```

**Reason for this issue**
Drush 9 alias stores the cloud path of Drupal in the option parameter.
So we face issue like below:
`The command "$(which drush-launcher || which drush.launcher || which drush) -r /var/www/html/xyz.test/docroot status --format=json" failed.`

**Fix**
we are adding an optional --root parameter to commands where user can pass the local path of Drupal 
