### PR TITLE
Composer --global is not valid command.

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ composer require --dev drutiny/drutiny 2.3.*@dev
 [Drush](http://docs.drush.org/en/master/) is also required. It's not specifically marked as a dependency as the version of Drush to use will depend on the site you're auditing.
 
 ```
-composer require --global drush/drush
+composer global require drush/drush:dev-master
 ```
 
 


### PR DESCRIPTION
Quick update to the documentation about using composer global command. --global is not a command. The correct way to locally require Drush globally is with `composer global require drush/drush:dev-master` Unless we want to specify which version of drush to use, then it would be something like `composer global require drush/drush:8.*`