### PR TITLE
Adds a fallback for ProfileSourceLocalFs to support phar localfs

### DIFF
--- a/src/Profile/ProfileSourceLocalFs.php
+++ b/src/Profile/ProfileSourceLocalFs.php
@@ -33,7 +33,9 @@ class ProfileSourceLocalFs implements ProfileSourceInterface {
 
     $list = [];
     foreach ($finder as $file) {
-      $filename = $file->getRealPath();
+      if (FALSE === $filename = $file->getRealPath()) {
+        $filename = $file->getPathname();
+      }
       $name = str_replace('.profile.yml', '', pathinfo($filename, PATHINFO_BASENAME));
       $profile = Yaml::parse($file->getContents());
       $profile['filepath'] = $filename;

--- a/src/Profile/ProfileSourceLocalFs.php
+++ b/src/Profile/ProfileSourceLocalFs.php
@@ -33,9 +33,7 @@ class ProfileSourceLocalFs implements ProfileSourceInterface {
 
     $list = [];
     foreach ($finder as $file) {
-      if (FALSE === $filename = $file->getRealPath()) {
-        $filename = $file->getPathname();
-      }
+      $filename = $file->getPathname();
       $name = str_replace('.profile.yml', '', pathinfo($filename, PATHINFO_BASENAME));
       $profile = Yaml::parse($file->getContents());
       $profile['filepath'] = $filename;


### PR DESCRIPTION
closes #252 

This PR simply introduces a fallback so that if `getRealPath()` returns `false` in the context of a phar, we can still attempt to extract the profile's short name from the in-archive file.

I'm submitting this since it seems like the simplest fix (without looking at things like determining runtime context etc.) that changes the least about the architecture of this class. Happy to dig in further on it as a second phase.