### PR TITLE
Changes site-alias to site:alias in getAvailableTargets().

### DIFF
--- a/src/Target/DrushTarget.php
+++ b/src/Target/DrushTarget.php
@@ -100,7 +100,7 @@ class DrushTarget extends Target implements TargetInterface, TargetSourceInterfa
      */
     public function getAvailableTargets():array
     {
-      $aliases = $this['service.local']->run('drush site-alias --format=json', function ($output) {
+      $aliases = $this['service.local']->run('drush site:alias --format=json', function ($output) {
         return json_decode($output, true);
       });
       $valid = array_filter(array_keys($aliases), function ($a) {


### PR DESCRIPTION
While running `target:list drush` I found that the command failed with the following error

```
The command "drush site-alias --format=json" failed.
```

This PR changes `site-alias` to use the `site:alias` format which is valid for Drush versions >=8