### PR TITLE
Adds logic to prevent Drush calls if Drupal can't be bootstrapped.

### DIFF
--- a/src/Audit/Drupal/ModuleAnalysis.php
+++ b/src/Audit/Drupal/ModuleAnalysis.php
@@ -13,18 +13,43 @@ class ModuleAnalysis extends AbstractAnalysis
 {
 
   /**
-   *
+   * {@inheritDoc}
    */
     public function gather(Sandbox $sandbox)
     {
+      $list = [];
+      $bootstrapped = FALSE;
+
+      // Drush must be able to bootstrap Drupal to run pm:list.
+      if ($this->drupalBootstrap()) {
+        $bootstrapped = TRUE;
         $list = $this->target->getService('drush')
           ->pmList([
             'format' => 'json',
-            'type' => 'module'
+            'type' => 'module',
           ])
           ->run(function ($output) {
-          return json_decode($output, true);
-        });
-        $this->set('modules', $list);
+            return json_decode($output, TRUE);
+          });
+      }
+      $this->set('modules', $list);
+      $this->set('bootstrapped', $bootstrapped);
     }
+
+  /**
+   * Determine if Drupal can be bootstrapped.
+   *
+   * @return bool
+   *   True if Drush can bootstrap Drupal.
+   */
+  private function drupalBootstrap(): bool {
+    $drush_status = $this->target->getService('drush')
+      ->status([
+        'format' => 'json',
+      ])
+      ->run(function ($output) {
+        return json_decode($output, TRUE);
+      });
+    return isset($drush_status['bootstrap']);
+  }
 }


### PR DESCRIPTION
This adds a `bootstrapped` variable so that policies which use this audit class can add a `not_applicable` expression to prevent errors if Drupal can't be bootstrapped. 

Example: 
```
parameters:
  not_applicable: 'bootstrapped == false'
```