### PR TITLE
#289  variable initialised to empty string.

### DIFF
--- a/src/Console/Command/PolicyAuditCommand.php
+++ b/src/Console/Command/PolicyAuditCommand.php
@@ -127,6 +127,7 @@ class PolicyAuditCommand extends DrutinyBaseCommand
         $progress->clear();
 
         foreach ($this->getFormats($input, $profile) as $format) {
+            $format->setNamespace($this->getReportNamespace($input, $uri));
             $format->render($profile, $assessment);
             foreach ($format->write() as $location) {
               $output->write("Policy Audit written to $location.");


### PR DESCRIPTION
Issue link: https://github.com/drutiny/drutiny/issues/289

In this fix:
Setting namespace in PolicyAudit command. Without setting namespace, it was generating filename like `DrutinyAssessmentResults__.csv`