### PR TITLE
Limit max depth for code scanning policies

### DIFF
--- a/src/Audit/Filesystem/CodeScan.php
+++ b/src/Audit/Filesystem/CodeScan.php
@@ -46,6 +46,11 @@ class CodeScan extends Audit
             static::PARAMETER_OPTIONAL,
             'Patterns which the \'patterns\' parameter may yield false positives from',
         );
+        $this->addParameter(
+            'maxdepth',
+            static::PARAMETER_OPTIONAL,
+            'An optional max depth for the scan.'
+        );
     }
 
 
@@ -67,6 +72,12 @@ class CodeScan extends Audit
         $directory =  strtr($directory, $stat['%paths']);
 
         $command = ['find', $directory, '-type f'];
+
+        // Add maxdepth to command if applicable.
+        $maxdepth = $this->getParameter('maxdepth', NULL);
+        if (is_int($maxdepth) && $maxdepth >= 0) {
+            $command[] = '-maxdepth ' . $maxdepth;
+        }
 
         $types = $this->getParameter('filetypes', []);
 

--- a/src/Audit/Filesystem/CodeScanAnalysis.php
+++ b/src/Audit/Filesystem/CodeScanAnalysis.php
@@ -39,6 +39,11 @@ class CodeScanAnalysis extends AbstractAnalysis
           static::PARAMETER_OPTIONAL,
           'Patterns which the \'patterns\' parameter may yield false positives from',
       );
+      $this->addParameter(
+          'maxdepth',
+          static::PARAMETER_OPTIONAL,
+          'An optional max depth for the scan.',
+      );
     }
 
 
@@ -63,6 +68,12 @@ class CodeScanAnalysis extends AbstractAnalysis
         $directory =  strtr($directory, $stat['%paths']);
 
         $command = ['find', $directory, '-type f'];
+
+        // Add maxdepth to command if applicable.
+        $maxdepth = $this->getParameter('maxdepth', NULL);
+        if (is_int($maxdepth) && $maxdepth >= 0) {
+            $command[] = '-maxdepth ' . $maxdepth;
+        }
 
         $types = $this->getParameter('filetypes', []);
 


### PR DESCRIPTION
Adds an optional maxdepth parameter to `\Drutiny\Audit\Filesystem\CodeScan` and `\Drutiny\Audit\Filesystem\CodeScanAnalysis`. When provided, limits the find command to the provided `-maxdepth`.