### PR TITLE
Fix Drutiny\Plugin\Drupal8\Audit\DuplicateModules: fix logic

### DIFF
--- a/src/Plugin/Drupal8/Audit/DuplicateModules.php
+++ b/src/Plugin/Drupal8/Audit/DuplicateModules.php
@@ -24,7 +24,7 @@ class DuplicateModules extends Audit
         $command = <<<CMD
 find \$DRUSH_ROOT -name '*.info.yml' -type f |\
 grep -Ev '/themes/|/test' |\
-grep -oe '[^/]*\.info.yml' | cut -d'.' -f1 | sort |\
+grep -oe '[^/]*\.info.yml' | sed -e 's/.info.yml//' | sort |\
 uniq -c | sort -nr | awk '{print $2": "$1}'
 CMD;
 


### PR DESCRIPTION
This fixes some false pickup of ... not even modules, just some files that happen to have .info.yml as an extension:

Before fix:

```
$ drutinycs policy:audit Drupal-8:DuplicateModules aht:@geodis.prod --uri=geodis.com
... snip ...
#### ❌ The codebase should not have duplicate modules - failure [SEV=normal]

Duplicate modules can cause a variety of strange behaviors should Drupal ever
unexpectedly load the wrong version.

The following duplicate modules have been found:
* core
```

After fix:
```
No duplicate modules found.
```