### PR TITLE
Drutiny\Audit\Drupal\RequirementsAnalysis: Add fields to drush core:requirements command

### DIFF
--- a/src/Audit/Drupal/RequirementsAnalysis.php
+++ b/src/Audit/Drupal/RequirementsAnalysis.php
@@ -17,7 +17,7 @@ class RequirementsAnalysis extends AbstractAnalysis
 {
     public function prepare(Policy $policy): ?string
     {
-      return static::class;  
+      return static::class;
     }
 
     #[DataProvider]
@@ -26,6 +26,7 @@ class RequirementsAnalysis extends AbstractAnalysis
         $list = $this->target->getService('drush')
           ->coreRequirements([
             'format' => 'json',
+            'fields' => 'title,severity,sid,description,value',
           ])
           ->run(function ($output) {
               return TextCleaner::decodeDirtyJson($output);


### PR DESCRIPTION
This adds an argument to the drush core:requirements command:

```
            'fields' => 'title,severity,sid,description,value',
```

If not we won't get the "good stuff" of information that shows in the Drupal status report.