### PR TITLE
ENT-11700: remove extra bytes on TSH sessions

### DIFF
--- a/src/Target/Transport/SshTransport.php
+++ b/src/Target/Transport/SshTransport.php
@@ -38,6 +38,7 @@ class SshTransport implements TransportInterface
             $comandline .= ' | base64 --decode | gzip -d';
         }
         $commandline = $this->getRemoteCall() . sprintf(" 'echo %s | base64 --decode | sh'", base64_encode($commandline));
+        $commandline .= ' | sed -z -e \'s/\x1B\[3J\x1Bc//g\'';
         $ssh_command = Process::fromShellCommandline($commandline);
         ProcessUtility::copyConfiguration($command, $ssh_command);
         return $this->localCommand->run($ssh_command, $processor);

--- a/src/Target/Transport/SshTransport.php
+++ b/src/Target/Transport/SshTransport.php
@@ -38,7 +38,7 @@ class SshTransport implements TransportInterface
             $comandline .= ' | base64 --decode | gzip -d';
         }
         $commandline = $this->getRemoteCall() . sprintf(" 'echo %s | base64 --decode | sh'", base64_encode($commandline));
-        $commandline .= ' | sed -z -e \'s/\x1B\[3J\x1Bc//g\'';
+        $commandline .= ' | sed -z -e \'s/\x1B\[3J\x1Bc\\n//g\'';
         $ssh_command = Process::fromShellCommandline($commandline);
         ProcessUtility::copyConfiguration($command, $ssh_command);
         return $this->localCommand->run($ssh_command, $processor);


### PR DESCRIPTION
Basically this passes the results of the `tsh` command through this `sed` command:

```
$comandline .= ' | sed -z -e \'s/\x1B\[3J\x1Bc\n//g\'';
```

This shows how it works from an interactive shell:

```
# No processing:
$ tsh bastion-21 'echo hello' |od -c
0000000   h   e   l   l   o  \r  \n 033   [   3   J 033   c  \n
0000016

# With processing
$ tsh bastion-21 'echo hello' |sed -z -e 's/\x1B\[3J\x1Bc\n//g' |od -c
0000000   h   e   l   l   o  \r  \n
0000007
```