### PR TITLE
HttpHeaderExists/HttpHeaderMatch classes should throw an Error for unreachable URLs (or with 403/404/5XX errors)

### DIFF
--- a/src/Http/Audit/HttpHeaderExists.php
+++ b/src/Http/Audit/HttpHeaderExists.php
@@ -2,6 +2,7 @@
 
 namespace Drutiny\Http\Audit;
 
+use Drutiny\Audit;
 use Drutiny\Sandbox\Sandbox;
 use GuzzleHttp\Exception\RequestException;
 use Psr\Http\Message\ResponseInterface;
@@ -49,7 +50,8 @@ class HttpHeaderExists extends Http
         } catch (RequestException $e) {
             $sandbox->logger()->error($e->getMessage());
             $this->set('request_error', $e->getMessage());
+            throw new \Exception("The audit was not able to get the HTTP headers; HTTP result code=" . $e->getCode());
+            return self::ERROR;
         }
-        return false;
     }
 }

--- a/src/Http/Audit/HttpHeaderMatch.php
+++ b/src/Http/Audit/HttpHeaderMatch.php
@@ -3,6 +3,7 @@
 namespace Drutiny\Http\Audit;
 
 use Drutiny\Sandbox\Sandbox;
+use GuzzleHttp\Exception\RequestException;
 
 /**
  *
@@ -26,14 +27,22 @@ class HttpHeaderMatch extends Http
 
     public function audit(Sandbox $sandbox)
     {
-        $value = $this->getParameter('header_value');
-        $res = $this->getHttpResponse($sandbox);
-        $header = $this->getParameter('header');
+        try {
+            $value = $this->getParameter('header_value');
+            $res = $this->getHttpResponse($sandbox);
+            $header = $this->getParameter('header');
 
-        if (!$res->hasHeader($header)) {
-            return false;
+            if (!$res->hasHeader($header)) {
+                return false;
+            }
+            $headers = $res->getHeader($header);
+            return $value == $headers[0];
         }
-        $headers = $res->getHeader($header);
-        return $value == $headers[0];
+        catch (RequestException $e) {
+            $sandbox->logger()->error($e->getMessage());
+            $this->set('request_error', $e->getMessage());
+            throw new \Exception("The audit was not able to get the HTTP headers; HTTP result code=" . $e->getCode());
+            return self::ERROR;
+        }
     }
 }


### PR DESCRIPTION
Instead of 'absorbing' the HTTP exception, the audits will generate an error. 