### PR TITLE
Preventing AuditAnalysisPipeline policies from being grouped together in a single thread

### DIFF
--- a/src/Audit/AuditAnalysisPipeline.php
+++ b/src/Audit/AuditAnalysisPipeline.php
@@ -21,6 +21,14 @@ use Twig\Error\RuntimeError;
 )]
 class AuditAnalysisPipeline extends AbstractAnalysis
 {
+    /**
+     * {@inheritdoc}
+     */
+    public function prepare(\Drutiny\Policy $policy): ?string
+    {
+        return 'audit_analysis_pipeline_' . mt_rand(1000, 9999);
+    }
+    
     #[DataProvider]
     protected function aggregateData(AuditFactory $factory, Sandbox $sandbox):void
     {


### PR DESCRIPTION
Policies from the same class get grouped together into a single thread like this:
![SCR-20250310-kcwo](https://github.com/user-attachments/assets/b1c9ac67-45cd-4048-bc87-76c4fe87ce03)

This PR will prevent the grouping so we can take advantage of the speed of multiple threads like this
![SCR-20250310-oggm](https://github.com/user-attachments/assets/2e7153be-dd9f-43e5-8fcf-72739e002ec6)
